### PR TITLE
Support proxy CLI arg

### DIFF
--- a/bin/npmo-license.js
+++ b/bin/npmo-license.js
@@ -39,5 +39,6 @@ if (argv.email && argv.key) {
 }
 
 process.on('uncaughtException', function (err) {
-  console.log(chalk.red(err.message + '. most likely you entered an incorrect email or key.'))
+  console.error(chalk.red(err.message + '. most likely you entered an incorrect email or key.'))
+  process.exit(1)
 })

--- a/bin/npmo-license.js
+++ b/bin/npmo-license.js
@@ -10,6 +10,10 @@ var argv = require('yargs')
     alias: 'key',
     description: 'license key associated with On-Site license'
   })
+  .option('p', {
+    alias: 'proxy',
+    description: 'address of HTTP proxy to use if needed'
+  })
   .help('help')
   .alias('h', 'help')
   .version(require('../package.json').version, 'version')

--- a/bin/npmo-license.js
+++ b/bin/npmo-license.js
@@ -17,7 +17,7 @@ var argv = require('yargs')
   .usage('download an up-to-date version of your npm On-Site license')
   .argv
 var License = require('../')
-var license = new License()
+var license = new License(argv)
 var chalk = require('chalk')
 
 if (argv.email && argv.key) {


### PR DESCRIPTION
Logic in _index.js_ already accounted for a `proxy` argument, but the bin logic wasn't passing the CLI arg to the `License` constructor. I fixed this by passing parsed `argv` to the constructor. Went ahead and added the proxy option to the CLI help text too.

Note that I also wanted to better support writing the fetched license json to file, but doing something like:

```
npmo-license -e me -k invalid > license.json
```

would result in error messages written to _license.json_ and nothing output in the terminal. I fixed this by using `console.error()` for the error message instead of using `console.log()`. Also fixed exit code on error.
